### PR TITLE
Misc: Из хедеров удален копирайт ИнфоТеКСа (он там был по ошибке)

### DIFF
--- a/beast/first.cpp
+++ b/beast/first.cpp
@@ -1,7 +1,7 @@
 /// @file first.cpp
 /// @brief
 ///
-/// @copyright Copyright 2019 InfoTeCS.
+
 
 #include <stdexcept>
 #include <iostream>

--- a/core/test/core_test.cpp
+++ b/core/test/core_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 

--- a/coroutine2/main.cpp
+++ b/coroutine2/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <stdexcept>
 #include <iostream>

--- a/datetime/main.cpp
+++ b/datetime/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <ctime>
 #include <iomanip>

--- a/filesystem/main.cpp
+++ b/filesystem/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <stdexcept>
 #include <iostream>

--- a/iostreams/base64.cpp
+++ b/iostreams/base64.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <iostreams/base64.h>
 

--- a/iostreams/base64.h
+++ b/iostreams/base64.h
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #pragma once
 

--- a/iostreams/benchmark/base64_benchmark.cpp
+++ b/iostreams/benchmark/base64_benchmark.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <fstream>
 #include <iterator>

--- a/iostreams/benchmark/filters_benchmark.cpp
+++ b/iostreams/benchmark/filters_benchmark.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <set>
 #include <sstream>

--- a/iostreams/benchmark/iostream_benchmark.cpp
+++ b/iostreams/benchmark/iostream_benchmark.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <fstream>
 #include <sstream>

--- a/iostreams/benchmark/main_benchmark.cpp
+++ b/iostreams/benchmark/main_benchmark.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <celero/Celero.h>
 

--- a/iostreams/consts.h
+++ b/iostreams/consts.h
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #pragma once
 

--- a/iostreams/filters.h
+++ b/iostreams/filters.h
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #pragma once
 

--- a/iostreams/iterator_source.h
+++ b/iostreams/iterator_source.h
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #pragma once
 

--- a/iostreams/main.cpp
+++ b/iostreams/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <vector>
 #include <istream>

--- a/iostreams/test/base64_test.cpp
+++ b/iostreams/test/base64_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>

--- a/iostreams/test/filters_test.cpp
+++ b/iostreams/test/filters_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <sstream>
 

--- a/iostreams/test/main_test.cpp
+++ b/iostreams/test/main_test.cpp
@@ -1,5 +1,5 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 #define BOOST_TEST_MAIN
 #include <boost/test/included/unit_test.hpp>

--- a/locale/charset_utils.h
+++ b/locale/charset_utils.h
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #pragma once
 

--- a/locale/src/charset_utils.cpp
+++ b/locale/src/charset_utils.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <locale/charset_utils.h>
 

--- a/locale/test/charset_utils_test.cpp
+++ b/locale/test/charset_utils_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 

--- a/multiindex/document.cpp
+++ b/multiindex/document.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <multiindex/document.h>
 

--- a/multiindex/document.h
+++ b/multiindex/document.h
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #pragma once
 

--- a/multiindex/main.cpp
+++ b/multiindex/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <stdexcept>
 #include <iostream>

--- a/property_tree/main.cpp
+++ b/property_tree/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <strings.h>
 

--- a/range/main.cpp
+++ b/range/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <vector>
 #include <stdexcept>

--- a/regex/main.cpp
+++ b/regex/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <stdexcept>
 #include <iostream>

--- a/serialization/main.cpp
+++ b/serialization/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <string>
 #include <stdexcept>

--- a/stacktrace/funcs/funcs.cpp
+++ b/stacktrace/funcs/funcs.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <stacktrace/funcs/funcs.h>
 

--- a/stacktrace/funcs/funcs.h
+++ b/stacktrace/funcs/funcs.h
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 
 #pragma once

--- a/stacktrace/main.cpp
+++ b/stacktrace/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <stdexcept>
 #include <iostream>

--- a/testing/custom_output_test.cpp
+++ b/testing/custom_output_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 

--- a/testing/dataset_test.cpp
+++ b/testing/dataset_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <ostream>
 #include <vector>

--- a/testing/enabling_disabling_test.cpp
+++ b/testing/enabling_disabling_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 

--- a/testing/fixture_test.cpp
+++ b/testing/fixture_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 

--- a/testing/general_assertions_test.cpp
+++ b/testing/general_assertions_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 

--- a/testing/initialize.cpp
+++ b/testing/initialize.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE TestModuleName

--- a/testing/ostream_test.cpp
+++ b/testing/ostream_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/output_test_stream.hpp>

--- a/testing/template_test.cpp
+++ b/testing/template_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 #include <boost/mpl/list.hpp>

--- a/testing/test_suites_test.cpp
+++ b/testing/test_suites_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 

--- a/testing/throw_test.cpp
+++ b/testing/throw_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 

--- a/testing/timeout_test.cpp
+++ b/testing/timeout_test.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <boost/test/unit_test.hpp>
 

--- a/tribool/main.cpp
+++ b/tribool/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <stdexcept>
 #include <iostream>

--- a/variant/main.cpp
+++ b/variant/main.cpp
@@ -1,6 +1,6 @@
 /// @file
 /// @brief
-/// @copyright Copyright (c) InfoTeCS. All Rights Reserved.
+
 
 #include <stdexcept>
 #include <iostream>


### PR DESCRIPTION
Копирайт компании попал в заголовочные файлы из настроек среды
разработки (Eclipse IDE C++), в которой для работы был настроен шаблон
хедера для создаваемых файлов.
Настройки перекочевали в Eclipse на домашнем ноутбуке и просочились в
исходники.